### PR TITLE
Small fixes to code

### DIFF
--- a/src/formats.hpp
+++ b/src/formats.hpp
@@ -5,7 +5,7 @@
  Functions for handling file formats.
  ************************************************/
 #ifndef SEAL_FORMATS_HPP
-#define SEAL_FORAMTS_HPP
+#define SEAL_FORMATS_HPP
 
 #include <stdlib.h>
 #include "seal.hpp"

--- a/src/sign-verify.cpp
+++ b/src/sign-verify.cpp
@@ -553,6 +553,7 @@ sealfield *	SealVerify	(sealfield *Rec, mmapfile *Mmap, mmapfile *MmapPre)
   char *rec_id,*dns_id; // for matching uid strings
   char *rec_ka,*dns_ka; // for matching ka strings
   char *rec_kv,*dns_kv; // for matching kv strings
+  char *rec_pk,*dns_p;  // for matching inline pubkey
   char *dns_str;
   bool IsValid=true; // assume it is valid
   bool IsInline=false;
@@ -694,7 +695,9 @@ sealfield *	SealVerify	(sealfield *Rec, mmapfile *Mmap, mmapfile *MmapPre)
       if(IsInline)
         {
         // The public key was already validated, and it being here means it was authenticated, if nto revoked
-        if(SealGetText(dnstxt,"p") == SealGetText(Rec, "pk"))
+        dns_p = SealGetText(dnstxt, "p");
+        rec_pk = SealGetText(Rec, "pk");
+        if(dns_p && rec_pk && !strcmp(dns_p, rec_pk))
           {
           Rec = _SealValidateRevoke(Rec,dnstxt);
           break; //regardless of if it is revoked the record was found


### PR DESCRIPTION
First commit is a fix on a typo in the name of the header which was `#define SEAL_FORAMTS_HPP` while the header file was checking for `#ifndef SEAL_FORMATS_HPP`.

The second fix is a comparison of 2 strings, where simply using `==` will compare pointers instead of the value of the strings, which is replaced with `strcmp()` function. 