### PR TITLE
Fixed #12: Updated usage and check for key algorithm

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -126,6 +126,8 @@ This code defaults to EC (P-256), but supports a wide range of ciphers (use `sea
 > [!WARNING]
 > Do not intentionally use weak ciphers for production use.
 
+When generating keys, the key algorithm is essential (e.g., `-K ec`). However, the command-line key algorithm parameter is ignored when signing or verifying. This is because the public and private key files encode the type of algorithm (ec or rsa).
+
 ## Current Status
 This release:
 - Supports a wide range of image, audio, video, and document files -- with more being added. All common web formats are supported, including JPEG, PNG, WebP, PDF, and MP4.

--- a/src/seal-dns.cpp
+++ b/src/seal-dns.cpp
@@ -294,6 +294,17 @@ void	SealDNSLoadFile	(const char *Fname)
 	SealBase64Decode(SealSearch(dnew->Rec,"@pkd-bin"));
 	}
 
+  // Make sure the key algorithm matches the key
+  sealfield *dns_pbin;
+  dns_pbin = SealSearch(dnew->Rec,"@p-bin");
+  if (dns_pbin && !SealCheckKeyKeyAlg(SealGetText(dnew->Rec,"ka"),dns_pbin))
+    {
+    MmapFree(Mmap);
+    SealFree(vBuf);
+    fprintf(stderr," ERROR: DNS file contains mismatched key algorithm. Aborting.\n");
+    exit(0x80);
+    }
+
   // Insert record
   dnew->Next = DNSCache;
   DNSCache = dnew;

--- a/src/seal.hpp
+++ b/src/seal.hpp
@@ -18,7 +18,7 @@
 #include <stdint.h>
 
 // Revise the version if there is any significant change
-#define SEAL_VERSION "0.1.9"
+#define SEAL_VERSION "0.1.10"
 
 #ifndef _GNU_SOURCE
     #define _GNU_SOURCE

--- a/src/sealtool.cpp
+++ b/src/sealtool.cpp
@@ -446,7 +446,7 @@ void	Usage	(const char *progname)
   printf("        -O text may contain a comma-separated list of options:\n");
   printf("        append  :: This is an appending signature; not final signature.\n");
   printf("        seAl,SEAL,teXt,tEXt,...  :: PNG: chunk name to use.\n");
-  printf("  -K, --keyalg alg     :: Key algorithm  (default: ec, P-256)\n");
+  // -K / --keyalg is ignored when signing or verifying; it is only used for key generation
   printf("  -A, --digestalg alg  :: Digest (hash) algorithm  (default: sha256)\n");
   printf("               Supports: sha224, sha256, sha384, sha512\n");
   printf("  --kv number          :: Unique key version (default: 1)\n");

--- a/src/sign-local.cpp
+++ b/src/sign-local.cpp
@@ -26,10 +26,12 @@
    ED25519: Adopted by NIST in 2019 as part of FIPS 186-5.
      OpenSSL doesn't (yet) support it with EVP_PKEY_sign_init
      https://github.com/openssl/openssl/issues/5873#issuecomment-378917092
-     ed25519 cannot be used with a separate digest.
+     ed25519 cannot be used with a separate digest. It's a two-pass algorithm.
+     ed25519 cannot be used on huge files (requires loading all data in RAM)
      Solution: https://github.com/openssl/openssl/pull/23240/files
      Openssl 3.3.2 does not work.
      Openssl 3.3.4 MAY not work. (waiting for official release)
+     Current status? Do not support ED25519.
  ************************************************/
 // C headers
 #include <stdlib.h>
@@ -361,6 +363,7 @@ EVP_PKEY *	SealLoadPrivateKey	(sealfield *Args)
   bool UseDeprecated = SealSearch(Args,"deprecated") ? true : false;
   if (type == EVP_PKEY_RSA)
     {
+    // Ignore any ka command-line parameter; this is RSA.
     Args = SealSetText(Args,"ka","rsa");
     if (bits % 8)
 	{
@@ -375,6 +378,7 @@ EVP_PKEY *	SealLoadPrivateKey	(sealfield *Args)
     } 
   else if (type == EVP_PKEY_EC)
     {
+    // Ignore any ka command-line parameter; this is EC.
     Args = SealSetText(Args,"ka","ec");
     if (bits < MIN_BITS_EC)
 	{

--- a/src/sign-verify.cpp
+++ b/src/sign-verify.cpp
@@ -392,6 +392,7 @@ DigestDone:
   if (PubKey) { EVP_PKEY_free(PubKey); }
   return Rec;
 }
+
 /********************************************************
  _SealValidateSig(): Given seal record with DNS results,
  and decoded binary signature, see if it validates!!!
@@ -435,6 +436,37 @@ sealfield *	_SealValidateSig	(sealfield *Rec, sealfield *dnstxt)
 } /* _SealValidateSig() */
 
 #pragma GCC visibility pop
+
+/********************************************************
+ SealCheckKeyKeyAlg(): Does the key encoding match the key algorithm?
+ Works for pbin being public or private.
+ Returns: true on match, false on miss.
+ ********************************************************/
+bool	SealCheckKeyKeyAlg	(const char *ka, sealfield *pbin)
+{
+  // ka is mandatory (even if redundant because the binary key says the algorithm)
+  // the public/private key must exist.
+  if (!ka || !pbin) { return(false); } // both must exist
+
+  EVP_PKEY *pkey;
+  const uint8_t *ppbin; // d2i moves the pointer; don't let it move
+  ppbin = pbin->Value;
+  // convert to pkey
+  pkey = d2i_PUBKEY(NULL, &ppbin, pbin->ValueLen);
+  if (!pkey) { return(false); } // needs to decode
+
+  if (!strcasecmp(ka,"rsa") && EVP_PKEY_is_a(pkey,"RSA"))
+    {
+    // ka is RSA and key is RSA
+    return(true);
+    }
+  if (!strcasecmp(ka,"ec") && EVP_PKEY_is_a(pkey,"EC"))
+    {
+    // ka is EC and key is EC
+    return(true);
+    }
+  return(false); // nope! mismatch!
+} /* SealCheckKeyKeyAlg() */
 
 /********************************************************
  SealValidateDecodeParts(): Given seal record with signature, decode the signature.
@@ -553,6 +585,9 @@ sealfield *	SealVerify	(sealfield *Rec, mmapfile *Mmap, mmapfile *MmapPre)
   char *rec_id,*dns_id; // for matching uid strings
   char *rec_ka,*dns_ka; // for matching ka strings
   char *rec_kv,*dns_kv; // for matching kv strings
+  char *rec_pk; // for matching pk strings
+  char *dns_p;  // for DNS keys
+  sealfield *dns_pbin; // for DNS keys
   char *dns_str;
   bool IsValid=true; // assume it is valid
   bool IsInline=false;
@@ -621,7 +656,8 @@ sealfield *	SealVerify	(sealfield *Rec, mmapfile *Mmap, mmapfile *MmapPre)
    * If inline verify the record, then do the DNS checks
    * else continue with the normal verifications
    *****/
-  if (!ErrorMsg && SealSearch(Rec, "pk"))
+  rec_pk = SealGetText(Rec, "pk");
+  if (!ErrorMsg && rec_pk)
     {
     sealfield *pubkey_bin;
     IsInline = true;
@@ -654,6 +690,7 @@ sealfield *	SealVerify	(sealfield *Rec, mmapfile *Mmap, mmapfile *MmapPre)
     rec_id = SealGetText(Rec,"uid");
     rec_ka = SealGetText(Rec,"ka");
     rec_kv = SealGetText(Rec,"kv");
+    rec_pk = SealGetText(Rec,"pk");
     for(dnsnum=0; (dnstxt=SealDNSGet(Rec,dnsnum)) != NULL; dnsnum++) // foreach dns record...
       {
       /* Copy DNS components to the record for verifying */
@@ -685,22 +722,28 @@ sealfield *	SealVerify	(sealfield *Rec, mmapfile *Mmap, mmapfile *MmapPre)
       else if (!rec_kv && dns_kv && !strcmp(dns_kv,"1")) { ; } // implicit match
       else { continue; } // missed
 
+      // Confirm DNS validation
+      dns_p = SealGetText(dnstxt,"p");
+      dns_pbin = SealSearch(dnstxt,"@p-bin");
+      if (dns_p && !dns_pbin)
+        {
+	// Public key failed to decode
+	continue;
+	}
+
       /*****
        If Rec contains inline-pubkey, then either:
        (A) match full p=, or
        (B) match digest using pka= and pkd=
        If neither matches, then it doesn't apply (continue).
        *****/
-      if(IsInline)
+      if (IsInline)
         {
         // The public key was already validated, and it being here means it was authenticated, if not revoked
-	char *p,*pk;
-	p = SealGetText(dnstxt,"p");
-	pk = SealGetText(Rec, "pk");
-        if (p && pk && !strcmp(p,pk))
+        if (dns_p && rec_pk && !strcmp(dns_p,rec_pk))
           {
           Rec = _SealValidateRevoke(Rec,dnstxt);
-          break; //regardless of if it is revoked the record was found
+          break; // regardless of whether it is revoked, the record was found
           }
         Rec = SealInlineAuthenticate(Rec);
         if (!SealGetText(Rec,"@error")) { break; } // It worked!
@@ -718,10 +761,15 @@ sealfield *	SealVerify	(sealfield *Rec, mmapfile *Mmap, mmapfile *MmapPre)
 	continue;
 	}
 
+      // Make sure the key matches the key algorithm
+      if (dns_str && !SealCheckKeyKeyAlg(rec_ka,dns_pbin)) { continue; }
+
       // There's a public key! See if it matched
       /* Check if the decoded digest matches the known digest. */
       Rec = _SealValidateSig(Rec,dnstxt);
       if (SealGetText(Rec,"@revoke")) { break; } // It is revoked!
+
+      // Everything matched
       if (!SealGetText(Rec,"@error")) { break; } // It worked!
       } // foreach DNS record
     } // if checking DNS

--- a/src/sign.hpp
+++ b/src/sign.hpp
@@ -40,6 +40,9 @@ void	PrintDNSstring	(FILE *fp, const char *Label, sealfield *vf);
 void	SealFreePrivateKey	();
 EVP_PKEY *	SealLoadPrivateKey	(sealfield *Args);
 
+// For key validation
+bool	SealCheckKeyKeyAlg	(const char *ka, sealfield *pbin);
+
 // Build a SEAL record
 sealfield *	SealRecord	(sealfield *Args);
 


### PR DESCRIPTION
Updated usage to only use -K for encoding, checking that DNS ka parameter matches the key.